### PR TITLE
Update go-vercel-client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect
-	github.com/sigmadigitalza/go-vercel-client/v2 v2.1.0
+	github.com/sigmadigitalza/go-vercel-client/v2 v2.1.1
 	github.com/zclconf/go-cty v1.8.3 // indirect
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5 // indirect
 	golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea // indirect

--- a/go.sum
+++ b/go.sum
@@ -272,6 +272,8 @@ github.com/sigmadigitalza/go-vercel-client/v2 v2.0.3 h1:GZYFI/c119MVfGlM1xOH7s6g
 github.com/sigmadigitalza/go-vercel-client/v2 v2.0.3/go.mod h1:iEOhhDIVLxnUklAQ6TESsk2q3MPxd6SyGEg1W7O/Kmg=
 github.com/sigmadigitalza/go-vercel-client/v2 v2.1.0 h1:Qg/wSCqpR6J0x+wNJOAM/vNfvEjcDoql/kqHRjElRyI=
 github.com/sigmadigitalza/go-vercel-client/v2 v2.1.0/go.mod h1:iEOhhDIVLxnUklAQ6TESsk2q3MPxd6SyGEg1W7O/Kmg=
+github.com/sigmadigitalza/go-vercel-client/v2 v2.1.1 h1:2ZlSUXCSQg4I+CnxNb1u+KO5yvPqZxxGkS8oJNFb+uo=
+github.com/sigmadigitalza/go-vercel-client/v2 v2.1.1/go.mod h1:iEOhhDIVLxnUklAQ6TESsk2q3MPxd6SyGEg1W7O/Kmg=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
## Context

There is a new `go-vercel-client` which has fixes related to the `buildCommand` and `outputDirectory`. Read more [here](https://github.com/sigmadigitalza/go-vercel-client/pull/2).

## Work Done

1. Updated to version `v2.1.1`