### PR TITLE
Framework fix and Import support

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -10,7 +10,7 @@ terraform {
 provider "vercel" {}
 
 resource "vercel_project" "test_project" {
-  name = "test_project"
+  name = "test-project"
   framework = "nextjs"
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect
-	github.com/sigmadigitalza/go-vercel-client/v2 v2.1.0
+	github.com/sigmadigitalza/go-vercel-client/v2 v2.1.2
 	github.com/zclconf/go-cty v1.8.3 // indirect
 	golang.org/x/net v0.0.0-20210525063256-abc453219eb5 // indirect
 	golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea // indirect

--- a/go.sum
+++ b/go.sum
@@ -272,6 +272,8 @@ github.com/sigmadigitalza/go-vercel-client/v2 v2.0.3 h1:GZYFI/c119MVfGlM1xOH7s6g
 github.com/sigmadigitalza/go-vercel-client/v2 v2.0.3/go.mod h1:iEOhhDIVLxnUklAQ6TESsk2q3MPxd6SyGEg1W7O/Kmg=
 github.com/sigmadigitalza/go-vercel-client/v2 v2.1.0 h1:Qg/wSCqpR6J0x+wNJOAM/vNfvEjcDoql/kqHRjElRyI=
 github.com/sigmadigitalza/go-vercel-client/v2 v2.1.0/go.mod h1:iEOhhDIVLxnUklAQ6TESsk2q3MPxd6SyGEg1W7O/Kmg=
+github.com/sigmadigitalza/go-vercel-client/v2 v2.1.2 h1:TWMjYaavDX6dv+1+E/fTHJBl4JLV1AmoCgbAIgNhC4Q=
+github.com/sigmadigitalza/go-vercel-client/v2 v2.1.2/go.mod h1:iEOhhDIVLxnUklAQ6TESsk2q3MPxd6SyGEg1W7O/Kmg=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -26,7 +26,7 @@ func resourceProject() *schema.Resource {
 			},
 			"framework": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"root_directory": {
 				Type:     schema.TypeString,
@@ -54,6 +54,9 @@ func resourceProject() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }

--- a/vercel/resource_project_domain.go
+++ b/vercel/resource_project_domain.go
@@ -33,6 +33,9 @@ func resourceProjectDomain() *schema.Resource {
 				Optional: true,
 			},
 		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }
 

--- a/vercel/resource_project_env.go
+++ b/vercel/resource_project_env.go
@@ -47,6 +47,9 @@ func resourceProjectEnv() *schema.Resource {
 				},
 			},
 		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 	}
 }
 


### PR DESCRIPTION
## Context

There is an update to the vercel client which now allows for the framework to be unspecified, allowing the user to set it to "Other".

## Work Done

1. Updated to the new vercel client
2. Corrected a bug in the example code 
3. Added the passthrough import config