### PR TITLE
Use ID for project name when importing project

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -268,10 +268,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
-github.com/sigmadigitalza/go-vercel-client/v2 v2.0.3 h1:GZYFI/c119MVfGlM1xOH7s6gVYEPapJTmwj07d+BkRc=
-github.com/sigmadigitalza/go-vercel-client/v2 v2.0.3/go.mod h1:iEOhhDIVLxnUklAQ6TESsk2q3MPxd6SyGEg1W7O/Kmg=
-github.com/sigmadigitalza/go-vercel-client/v2 v2.1.0 h1:Qg/wSCqpR6J0x+wNJOAM/vNfvEjcDoql/kqHRjElRyI=
-github.com/sigmadigitalza/go-vercel-client/v2 v2.1.0/go.mod h1:iEOhhDIVLxnUklAQ6TESsk2q3MPxd6SyGEg1W7O/Kmg=
 github.com/sigmadigitalza/go-vercel-client/v2 v2.1.2 h1:TWMjYaavDX6dv+1+E/fTHJBl4JLV1AmoCgbAIgNhC4Q=
 github.com/sigmadigitalza/go-vercel-client/v2 v2.1.2/go.mod h1:iEOhhDIVLxnUklAQ6TESsk2q3MPxd6SyGEg1W7O/Kmg=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=

--- a/vercel/resource_project.go
+++ b/vercel/resource_project.go
@@ -98,6 +98,9 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 func resourceProjectRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*vercel.Client)
 	name := d.Get("name").(string)
+	if name == "" {
+		name = d.Id()
+	}
 
 	project, err := client.Project.GetProject(ctx, name)
 	if err != nil {


### PR DESCRIPTION
## Scope

Importing of a project currently gives an error. This is because the `name` field is not set on the `schema.ResourceData` when the import process calls the read function. During an import, we should be using `schema.ResourceData.Id()` instead. 

## Work Done

1. Use the `.Id()` method when the `name` field is not present

## Notes

[This was used as a reference](https://www.terraform.io/docs/extend/resources/import.html#importer-state-function)