### PR TITLE
Fix domain import

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,32 @@ The provider requires the following environment variables:
 | VERCEL_TEAM_ID | - | A Vercel Team ID for working with a team rather than the token's user |
 
 See the [example](./examples/main.tf) directory for an example usage.
+
+## Importing existing resources
+
+Any IDs of existing resources required for importing with the following commands can be found using the
+[Vercel API](https://vercel.com/docs/rest-api#endpoints/projects/find-a-project-by-id-or-name)
+
+### Vercel projects
+
+Use the following format to import a Vercel project:
+
+```shell
+terraform import vercel_project.test_project <vercel-project-name>
+```
+
+### Domains
+
+Use the following format to import a domain:
+
+```shell
+terraform import vercel_project_domain.test_domain <vercel-project-name>:<domain-name>
+```
+
+### Environmental Variables
+
+Use the following format to import an env:
+
+```shell
+terraform import vercel_project_env.test_env <vercel-project-name>:<env-id>
+```

--- a/vercel/provider.go
+++ b/vercel/provider.go
@@ -10,9 +10,9 @@ import (
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		ConfigureContextFunc: configureContext,
-		ResourcesMap:         map[string]*schema.Resource {
-			"vercel_project": resourceProject(),
-			"vercel_project_env": resourceProjectEnv(),
+		ResourcesMap: map[string]*schema.Resource{
+			"vercel_project":        resourceProject(),
+			"vercel_project_env":    resourceProjectEnv(),
 			"vercel_project_domain": resourceProjectDomain(),
 		},
 	}

--- a/vercel/resource_project_domain.go
+++ b/vercel/resource_project_domain.go
@@ -6,11 +6,40 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	vercel "github.com/sigmadigitalza/go-vercel-client/v2"
+	"strings"
 )
 
 var (
 	ProjectDomainNotFoundError = errors.New("project domain not found")
+	InvalidDomainIdError = errors.New("invalid domain ID specified")
 )
+
+func importStateProjectDomainContext(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	id := d.Id()
+
+	// for importing of domains, specify the id in the following format: "vercel-project-name:domain-name
+	if strings.Contains(id, ":") {
+		values := strings.Split(id, ":")
+
+		if len(values) != 2 {
+			return nil, InvalidDomainIdError
+		}
+
+		err := d.Set("name", values[0])
+		if err != nil {
+			return nil, err
+		}
+
+		err = d.Set("domain", values[1])
+		if err != nil {
+			return nil, err
+		}
+
+		d.SetId(values[1])
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
 
 func resourceProjectDomain() *schema.Resource {
 	return &schema.Resource{
@@ -34,7 +63,7 @@ func resourceProjectDomain() *schema.Resource {
 			},
 		},
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: importStateProjectDomainContext,
 		},
 	}
 }

--- a/vercel/resource_project_domain.go
+++ b/vercel/resource_project_domain.go
@@ -17,7 +17,7 @@ var (
 func importStateProjectDomainContext(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 	id := d.Id()
 
-	// for importing of domains, specify the id in the following format: "vercel-project-name:domain-name
+	// for importing of domains, specify the id in the following format: "vercel-project-name:domain-name"
 	if strings.Contains(id, ":") {
 		values := strings.Split(id, ":")
 

--- a/vercel/resource_project_domain.go
+++ b/vercel/resource_project_domain.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	ProjectDomainNotFoundError = errors.New("project domain not found")
-	InvalidDomainIdError = errors.New("invalid domain ID specified")
+	InvalidDomainIdError       = errors.New("invalid domain ID specified")
 )
 
 func importStateProjectDomainContext(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
@@ -44,21 +44,21 @@ func importStateProjectDomainContext(ctx context.Context, d *schema.ResourceData
 func resourceProjectDomain() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceProjectDomainCreate,
-		ReadContext: resourceProjectDomainRead,
+		ReadContext:   resourceProjectDomainRead,
 		UpdateContext: resourceProjectDomainUpdate,
 		DeleteContext: resourceProjectDomainDestroy,
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Required: true,
 			},
 			"domain": {
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 			"redirect": {
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 		},

--- a/vercel/resource_project_env.go
+++ b/vercel/resource_project_env.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	EnvNotFoundError = errors.New("project env not found")
+	EnvNotFoundError  = errors.New("project env not found")
 	InvalidEnvIdError = errors.New("invalid env ID specified")
 )
 
@@ -44,7 +44,7 @@ func resourceProjectEnv() *schema.Resource {
 		DeleteContext: resourceProjectEnvDelete,
 		Schema: map[string]*schema.Schema{
 			"id": {
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"name": {


### PR DESCRIPTION
## Scope

Currently we have some bugs which mean that it is not possible to import domains or envs. This is due to how the get function is passed data, specifically just the ID, which is not enough to identify the Vercel project, from which these resources are derived.

## Work Done

1. For importing, specifically, we defined a ID format of `<project-name>:<domain-name|env-id>` which provides enough information for the import
2. The id is then mapped back to the expected ID
3. Documented the import scenarios in the README
4. Formatted the directory

-----
[View rendered README.md](https://github.com/sigmadigitalza/terraform-provider-vercel/blob/fix-domain-import/README.md)